### PR TITLE
Add basic batch rendering support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,10 +1,10 @@
-cmake_minimum_required(VERSION 3.29)
+cmake_minimum_required(VERSION 3.28)
 project(ZombieAttack)
 
 set(CMAKE_CXX_STANDARD 20)
 
-find_library(GLFW_LIBRARY NAMES glfw3 PATHS "${CMAKE_SOURCE_DIR}/dependencies/lib")
-find_library(ASSIMP_LIBRARY NAMES libassimp.5.4.3.dylib PATHS "${CMAKE_SOURCE_DIR}/dependencies/lib")
+find_package(glfw3 3.3 REQUIRED)
+find_package(assimp REQUIRED)
 include_directories("${CMAKE_SOURCE_DIR}/dependencies/include")
 
 set(IMGUI_DIR "${CMAKE_SOURCE_DIR}/dependencies/include/imgui")
@@ -68,6 +68,8 @@ add_executable(ZombieAttack
         src/ECS/IdGenerator.h
         src/Renderer/Renderer.cpp
         src/Renderer/Renderer.hpp
+        src/Renderer/BatchRenderer.cpp
+        src/Renderer/BatchRenderer.hpp
         src/Core/BaseShapes.hpp
         src/Core/Macros.hpp
         src/ECS/ScriptableEntity.hpp
@@ -94,7 +96,7 @@ add_executable(ZombieAttack
 )
 
 if(APPLE)
-    target_link_libraries(ZombieAttack ${GLFW_LIBRARY} ${ASSIMP_LIBRARY} ${COREFOUNDATION_LIBRARY} ${COREGRAPHICS_LIBRARY} ${IOKIT_LIBRARY} ${COCOA_LIBRARY})
+    target_link_libraries(ZombieAttack glfw assimp ${COREFOUNDATION_LIBRARY} ${COREGRAPHICS_LIBRARY} ${IOKIT_LIBRARY} ${COCOA_LIBRARY})
 else()
-    target_link_libraries(ZombieAttack ${GLFW_LIBRARY} ${ASSIMP_LIBRARY})
+    target_link_libraries(ZombieAttack glfw assimp)
 endif()

--- a/src/Collisions/OrientedBoundingBox.cpp
+++ b/src/Collisions/OrientedBoundingBox.cpp
@@ -1,4 +1,5 @@
 #include "OrientedBoundingBox.hpp"
+#include <memory>
 
 namespace Collisions {
     OrientedBoundingBox ComputeOrientedBoundingBox(const std::vector<std::shared_ptr<Core::Mesh>>& meshes, const glm::mat4& transform)

--- a/src/Collisions/OrientedBoundingBox.hpp
+++ b/src/Collisions/OrientedBoundingBox.hpp
@@ -3,6 +3,7 @@
 
 #include <vector>
 #include <glm/glm.hpp>
+#include <memory>
 
 #include "Core/Mesh.hpp"
 

--- a/src/Core/Mesh.cpp
+++ b/src/Core/Mesh.cpp
@@ -25,9 +25,12 @@ namespace Core {
         _ebo.Delete();
     }
 
-    void Mesh::Draw(const Shader& shader, const std::vector<std::function<void(const Shader&)>>& setFunctions) const
+    void Mesh::Draw(const Shader& shader, const std::vector<std::function<void(const Shader&)>>& setFunctions, bool bindShader) const
     {
-        shader.Use();
+        if (bindShader)
+        {
+            shader.Use();
+        }
         _vao.Bind();
         for (const auto& setFunction : setFunctions) {
             setFunction(shader);

--- a/src/Core/Mesh.hpp
+++ b/src/Core/Mesh.hpp
@@ -14,7 +14,7 @@ namespace Core {
     public:
         Mesh(std::vector<Vertex> vertices, std::vector<unsigned int> indices);
         ~Mesh();
-        void Draw(const Shader& shader, const std::vector<std::function<void(const Shader&)>>& setFunctions) const;
+        void Draw(const Shader& shader, const std::vector<std::function<void(const Shader&)>>& setFunctions, bool bindShader = true) const;
         VAO GetVAO() const;
         std::vector<Vertex> GetVertices() const { return _vertices; }
         std::vector<unsigned int> GetIndices() const { return _indices; }

--- a/src/Core/Model.cpp
+++ b/src/Core/Model.cpp
@@ -1,6 +1,7 @@
 #include "Model.hpp"
 
 #include <iostream>
+#include <memory>
 
 namespace Core {
     Model::Model(const std::string& path)
@@ -8,11 +9,15 @@ namespace Core {
         LoadModel(path);
     }
 
-    void Model::Draw(const Shader &shader, const std::vector<std::function<void(const Shader &)>> &setFunctions) const
+    void Model::Draw(const Shader &shader, const std::vector<std::function<void(const Shader &)>> &setFunctions, bool bindShader) const
     {
+        if (bindShader)
+        {
+            shader.Use();
+        }
         for (auto &mesh : _meshes)
         {
-            mesh->Draw(shader, setFunctions);
+            mesh->Draw(shader, setFunctions, false);
         }
     }
 

--- a/src/Core/Model.hpp
+++ b/src/Core/Model.hpp
@@ -5,13 +5,14 @@
 #include <assimp/scene.h>
 #include <assimp/postprocess.h>
 #include "Mesh.hpp"
+#include <memory>
 
 namespace Core {
     class Model
     {
     public:
         explicit Model(const std::string& path);
-        void Draw(const Shader& shader, const std::vector<std::function<void(const Shader&)>>& setFunctions) const;
+        void Draw(const Shader& shader, const std::vector<std::function<void(const Shader&)>>& setFunctions, bool bindShader = true) const;
         std::vector<std::shared_ptr<Mesh>> GetMeshes() const { return _meshes; }
     private:
         std::vector<std::shared_ptr<Mesh>> _meshes;

--- a/src/Core/WindowManager.hpp
+++ b/src/Core/WindowManager.hpp
@@ -5,6 +5,7 @@
 #include <vector>
 #include <glad/glad.h>
 #include <GLFW/glfw3.h>
+#include <memory>
 
 namespace Core {
     struct Resolution

--- a/src/Events/EventBus.cpp
+++ b/src/Events/EventBus.cpp
@@ -1,4 +1,5 @@
 #include <Events/EventBus.hpp>
+#include <memory>
 
 namespace Events {
     std::unordered_map<EventType, std::vector<std::function<void(Event&)>>> EventBus::_handlers;

--- a/src/Events/EventBus.hpp
+++ b/src/Events/EventBus.hpp
@@ -1,6 +1,10 @@
 #ifndef EVENTBUS_HPP
 #define EVENTBUS_HPP
 #include <functional>
+#include <memory>
+#include <unordered_map>
+#include <vector>
+#include <type_traits>
 
 #include "Event.hpp"
 

--- a/src/Renderer/BatchRenderer.cpp
+++ b/src/Renderer/BatchRenderer.cpp
@@ -1,0 +1,89 @@
+#include "BatchRenderer.hpp"
+
+#include "Scene/Components.hpp"
+#include "Core/Macros.hpp"
+
+#include <algorithm>
+
+namespace Renderer {
+    void BatchRenderer::DrawBatch(const std::vector<ECS::Entity>& entities, const Core::Camera& camera, const ECS::Entity& lightEntity)
+    {
+        ZA_ASSERT(lightEntity.HasComponent<Scene::LightComponent>(), "Light entity must have a LightComponent");
+
+        std::vector<ECS::Entity> drawable;
+        drawable.reserve(entities.size());
+        for (const auto& entity : entities)
+        {
+            if (entity.HasComponent<Scene::TransformComponent>() &&
+                (entity.HasComponent<Scene::MeshComponent>() || entity.HasComponent<Scene::ModelComponent>()) &&
+                entity.HasComponent<Scene::SpriteRendererComponent>())
+            {
+                drawable.push_back(entity);
+            }
+        }
+
+        std::sort(drawable.begin(), drawable.end(), [](const ECS::Entity& a, const ECS::Entity& b){
+            const Core::Shader* shaderA = nullptr;
+            const Core::Shader* shaderB = nullptr;
+            if (a.HasComponent<Scene::MeshComponent>())
+                shaderA = a.GetComponent<Scene::MeshComponent>().Shader.get();
+            else if (a.HasComponent<Scene::ModelComponent>())
+                shaderA = a.GetComponent<Scene::ModelComponent>().Shader.get();
+            if (b.HasComponent<Scene::MeshComponent>())
+                shaderB = b.GetComponent<Scene::MeshComponent>().Shader.get();
+            else if (b.HasComponent<Scene::ModelComponent>())
+                shaderB = b.GetComponent<Scene::ModelComponent>().Shader.get();
+            return shaderA < shaderB;
+        });
+
+        const auto& light = lightEntity.GetComponent<Scene::LightComponent>();
+        Core::Shader* currentShader = nullptr;
+
+        for (const auto& entity : drawable)
+        {
+            std::shared_ptr<Core::Shader> shader;
+            bool hasMesh = entity.HasComponent<Scene::MeshComponent>();
+            std::shared_ptr<Core::Mesh> mesh;
+            std::shared_ptr<Core::Model> model;
+            if (hasMesh)
+            {
+                const auto& comp = entity.GetComponent<Scene::MeshComponent>();
+                shader = comp.Shader;
+                mesh = comp.Mesh;
+            }
+            else
+            {
+                const auto& comp = entity.GetComponent<Scene::ModelComponent>();
+                shader = comp.Shader;
+                model = comp.Model;
+            }
+
+            if (shader.get() != currentShader)
+            {
+                currentShader = shader.get();
+                currentShader->Use();
+            }
+
+            const auto& transform = entity.GetComponent<Scene::TransformComponent>();
+            const auto& spriteRenderer = entity.GetComponent<Scene::SpriteRendererComponent>();
+            const std::vector<std::function<void(const Core::Shader&)>> setFunctions = {
+                [&](const Core::Shader& s) { s.SetMat4("view", camera.GetViewMatrix()); },
+                [&](const Core::Shader& s) { s.SetMat4("projection", camera.GetProjectionMatrix()); },
+                [&](const Core::Shader& s) { s.SetMat4("model", transform.Transform); },
+                [&](const Core::Shader& s) { s.SetVec4("spriteColor", spriteRenderer.Color); },
+                [&](const Core::Shader& s) { s.SetVec4("lightColor", light.Color); },
+                [&](const Core::Shader& s) { s.SetVec3("lightPos", light.Position); },
+                [&](const Core::Shader& s) { s.SetVec3("viewPos", camera.GetPosition()); }
+            };
+
+            if (hasMesh)
+            {
+                mesh->Draw(*shader, setFunctions, false);
+            }
+            else
+            {
+                model->Draw(*shader, setFunctions, false);
+            }
+        }
+    }
+}

--- a/src/Renderer/BatchRenderer.hpp
+++ b/src/Renderer/BatchRenderer.hpp
@@ -1,0 +1,17 @@
+#ifndef BATCH_RENDERER_HPP
+#define BATCH_RENDERER_HPP
+
+#include "Core/Camera.hpp"
+#include "ECS/Entity.hpp"
+
+#include <vector>
+
+namespace Renderer {
+    class BatchRenderer
+    {
+    public:
+        static void DrawBatch(const std::vector<ECS::Entity>& entities, const Core::Camera& camera, const ECS::Entity& lightEntity);
+    };
+}
+
+#endif //BATCH_RENDERER_HPP

--- a/src/Scene/Scene.cpp
+++ b/src/Scene/Scene.cpp
@@ -8,6 +8,7 @@
 #include "Events/EventBus.hpp"
 #include "ECS/Entity.hpp"
 #include "Renderer/Renderer.hpp"
+#include "Renderer/BatchRenderer.hpp"
 
 namespace Scene {
     ECS::Entity Scene::AddEntity()
@@ -81,11 +82,14 @@ namespace Scene {
 
         int firstLight = *firstLightIt;
         const ECS::Entity mainLight(firstLight, this);
+
+        std::vector<ECS::Entity> drawEntities;
+        drawEntities.reserve(_entities.size());
         for (const auto& entityId : _entities)
         {
-            ECS::Entity entity(entityId, this);
-            Renderer::Renderer::Draw(entity, camera, mainLight);
+            drawEntities.emplace_back(entityId, this);
         }
+        Renderer::BatchRenderer::DrawBatch(drawEntities, camera, mainLight);
     }
 
     void Scene::RemoveEntity(const int id)


### PR DESCRIPTION
## Summary
- implement `BatchRenderer` to reduce shader binds
- expose new batch drawing in `Scene`
- allow meshes and models to draw without rebinding shaders
- update CMake to find glfw/assimp automatically
- add missing headers for `std::shared_ptr`

## Testing
- `cmake -B build -S .`
- `cmake --build build`


------
https://chatgpt.com/codex/tasks/task_e_685650aa519c832aab2dd09b5a2b4e10